### PR TITLE
[ux] Alias "view" to "get"

### DIFF
--- a/commands/document.js
+++ b/commands/document.js
@@ -19,6 +19,7 @@ document.list = function () {
   db.list(params, helpers.generic_cb(callback));
 };
 
+document.view =
 document.get = function (name) {
   var err;
 


### PR DESCRIPTION
A quick hack to make "view" work as an alias for "get". For example:

```

josh@onix:~/dev/futoncli$ futon document view jesusabdullah
info:   Welcome to futon
info:   It worked if it ends with futon ok
info:   Executing command document view jesusabdullah
data:   
data:   {
data:       resource: 'User',
data:       _rev: '16-f7d45298487ecd79341a5a7c70270e40',
data:       username: 'jesusabdullah',
data:       password-salt: '********'
data:       mtime: 1339699930624,
data:       _id: 'jesusabdullah',
data:       profile: {},
data:       email: 'josh.holbrook@gmail.com',
data:       status: 'active',
data:       password: '********'
data:   }
data:   
info:   futon ok
josh@onix:~/dev/futoncli$ 
```
