### PR TITLE
[feature] pipe support for insert

### DIFF
--- a/commands/document.js
+++ b/commands/document.js
@@ -66,8 +66,8 @@ document.insert = function (name, callback) {
     name = null;
   }
 
-  // Tests are failing because a spawn node process, the stdin.isTTY is always
-  // undefined, I'm using the --test flag when running tests to avoid the
+  // Tests were failing because in a spawn node process, the stdin.isTTY is always
+  // undefined, so I'm using the --test flag when running tests to avoid the
   // conflict with nixt.
   if (!process.stdin.isTTY && !futoncli.argv.test) {
     process.stdin.pipe(concat(function (body) {

--- a/commands/document.js
+++ b/commands/document.js
@@ -66,7 +66,10 @@ document.insert = function (name, callback) {
     name = null;
   }
 
-  if (!process.stdin.isTTY) {
+  // Tests are failing because a spawn node process, the stdin.isTTY is always
+  // undefined, I'm using the --test flag when running tests to avoid the
+  // conflict with nixt.
+  if (!process.stdin.isTTY && !futoncli.argv.test) {
     process.stdin.pipe(concat(function (body) {
       return insert(body, name, callback);
     }));

--- a/commands/document.js
+++ b/commands/document.js
@@ -1,5 +1,6 @@
 var fs = require('fs');
 var path = require('path');
+var concat = require('concat-stream');
 var futoncli = require('../futoncli');
 var helpers = require('../helpers');
 
@@ -65,28 +66,44 @@ document.insert = function (name, callback) {
     name = null;
   }
 
-  var db = futoncli.db;
+  if (!process.stdin.isTTY) {
+    process.stdin.pipe(concat(function (body) {
+      return insert(body, name, callback);
+    }));
+    process.stdin.resume();
+  } else {
+    return promptFile();
+  }
 
-  futoncli.prompt.get("file", function (err, input) {
-    if(err) {
-      return callback(err);
-    }
-    fs.readFile(input.file, function (err, body) {
+  function promptFile() {
+    futoncli.prompt.get("file", function (err, input) {
       if(err) {
         return callback(err);
       }
-      try {
-        body = JSON.parse(body);
-        if(name) {
-          db.insert(body, name, helpers.generic_cb(callback));
-        } else {
-          db.insert(body, helpers.generic_cb(callback));
+      fs.readFile(input.file, function (err, body) {
+        if(err) {
+          return callback(err);
         }
-      } catch (err2) {
-        return callback(err2);
-      }
+
+        return insert(body, name, callback);
+       });
     });
-  });
+  }
+
+  function insert(body, name, callback) {
+    var db = futoncli.db;
+
+    try {
+      body = JSON.parse(body);
+      if(name) {
+        db.insert(body, name, helpers.generic_cb(callback));
+      } else {
+        db.insert(body, helpers.generic_cb(callback));
+      }
+    } catch (err2) {
+      return callback(err2);
+    }
+  }
 };
 
 document.update = function () {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   { "nano"                 : "3.0.x"
   , "flatiron"             : "0.3.x"
   , "colors"               : "0.6.x"
+  , "concat-stream"        : "1.2.x"
   , "flatiron-cli-config"  : "0.1.x"
   , "flatiron-cli-version" : "0.1.x"
   }

--- a/test/commands/document.js
+++ b/test/commands/document.js
@@ -2,9 +2,11 @@ var specify      = require('specify')
   , helpers      = require('../helpers')
   , fixture      = require('../fixtures/test_doc.json')
   , run          = helpers.run
+  , nixt         = helpers.nixt
   , futon_ok     = helpers.futon_ok
   , futon_not_ok = helpers.futon_not_ok
   , get_config   = helpers.get_config
+  , config_path  = helpers.config_path
   , rev
   ;
 
@@ -39,6 +41,21 @@ specify("futon document insert tdoc --file test/fixtures/test_doc.json", functio
 
   run("futon document insert tdoc --file ../test/fixtures/test_doc.json")
   .expect(function (response) {
+    console.log(response);
+    futon_ok(assert, response);
+  })
+  .end(function () {
+    assert.ok(true);
+  });
+});
+
+specify("cat test_doc.json | futon document insert tdocpipe", function (assert) {
+  assert.expect(3);
+
+  nixt()
+  .run("cat ../test/fixtures/test_doc.json | ./futon document insert tdocpipe -q " + config_path)
+  .expect(function (response) {
+    console.log(response);
     futon_ok(assert, response);
   })
   .end(function () {

--- a/test/commands/document.js
+++ b/test/commands/document.js
@@ -7,7 +7,7 @@ var specify      = require('specify')
   , futon_not_ok = helpers.futon_not_ok
   , get_config   = helpers.get_config
   , config_path  = helpers.config_path
-  , rev
+  , rev, rev2
   ;
 
 helpers.setup();
@@ -39,9 +39,8 @@ specify("futon document list", function (assert) {
 specify("futon document insert tdoc --file test/fixtures/test_doc.json", function (assert) {
   assert.expect(3);
 
-  run("futon document insert tdoc --file ../test/fixtures/test_doc.json")
+  run("futon document insert tdoc --file ../test/fixtures/test_doc.json --test")
   .expect(function (response) {
-    console.log(response);
     futon_ok(assert, response);
   })
   .end(function () {
@@ -55,7 +54,6 @@ specify("cat test_doc.json | futon document insert tdocpipe", function (assert) 
   nixt()
   .run("cat ../test/fixtures/test_doc.json | ./futon document insert tdocpipe -q " + config_path)
   .expect(function (response) {
-    console.log(response);
     futon_ok(assert, response);
   })
   .end(function () {
@@ -82,6 +80,19 @@ specify("futon document get tdoc", function (assert) {
   .expect(function (response) {
     futon_ok(assert, response);
     rev = response.stdout.match("_rev: \\'(.*)\\'")[1];
+  })
+  .end(function () {
+    assert.ok(true);
+  });
+});
+
+specify("futon document get tdocpipe", function (assert) {
+  assert.expect(3);
+
+  run("futon document get tdocpipe")
+  .expect(function (response) {
+    futon_ok(assert, response);
+    rev2 = response.stdout.match("_rev: \\'(.*)\\'")[1];
   })
   .end(function () {
     assert.ok(true);
@@ -120,6 +131,17 @@ specify("futon document destroy", function (assert) {
 specify("futon document destroy tdoc", function (assert) {
   assert.expect(3);
   run("futon document destroy tdoc " + rev)
+  .expect(function (response) {
+    futon_ok(assert, response);
+  })
+  .end(function () {
+    assert.ok(true);
+  });
+});
+
+specify("futon document destroy tdocpipe", function (assert) {
+  assert.expect(3);
+  run("futon document destroy tdocpipe " + rev2)
   .expect(function (response) {
     futon_ok(assert, response);
   })

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -16,6 +16,8 @@ var base_config = {
   userconfig: config_path
 };
 
+helpers.config_path = config_path;
+
 helpers.setup = function setup() {
   if (!fs.existsSync(config_path) || fs.readFileSync(config_path).length === 0) {
     fs.writeFileSync(config_path, JSON.stringify(base_config));
@@ -39,6 +41,11 @@ helpers.run = function run(cmd) {
   return nixt({ colors: false })
          .cwd(futon_cwd)
          .run(command);
+};
+
+helpers.nixt = function () {
+  return nixt({ colors: false })
+         .cwd(futon_cwd);
 };
 
 helpers.get_config = function () {


### PR DESCRIPTION
```
$ cat nuno.json | futon document insert 
```

This works only for documents, isn't tested with attachments. Addresses #7 
